### PR TITLE
Don't use transient when WP_DEBUG=true

### DIFF
--- a/functions/wpt_transient.php
+++ b/functions/wpt_transient.php
@@ -17,7 +17,7 @@
 		}
 		
 		function get($name, $args) {
-			if ( is_user_logged_in() ) {
+			if ( is_user_logged_in() || WP_DEBUG ) {
 				return false;
 			}
 			$key = 'wpt'.$name.md5(serialize($args));


### PR DESCRIPTION
The transient makes testing difficult, eg. when modifying the event template using filters.